### PR TITLE
Make Allow middleware thread-safe without duping

### DIFF
--- a/lib/strong_routes.rb
+++ b/lib/strong_routes.rb
@@ -1,4 +1,4 @@
-require "rack/request"
+require "rack/response"
 
 require "strong_routes/allow"
 require "strong_routes/config"
@@ -6,8 +6,16 @@ require "strong_routes/route_matcher"
 require "strong_routes/version"
 
 module StrongRoutes
+  def self.allowed?(route)
+    config.route_matchers.any? { |route_matcher| route_matcher =~ route }
+  end
+
   def self.config
     @config ||= Config.new
+  end
+
+  def self.enabled?
+    config.enabled?
   end
 
   # Initialize the config

--- a/lib/strong_routes/allow.rb
+++ b/lib/strong_routes/allow.rb
@@ -1,54 +1,23 @@
 module StrongRoutes
   class Allow
-    def initialize(app, options = {})
+    def initialize(app)
       @app = app
-      @options = options
     end
 
-    def _call(env)
-      return @app.call(env) unless enabled?
+    def call(env)
+      return @app.call(env) unless config.enabled?
 
-      request = ::Rack::Request.new(env)
-
-      if allowed?(request)
+      if StrongRoutes.allowed?(env[Rack::PATH_INFO].to_s)
         @app.call(env)
       else
         [404, {"Content-Type" => "text/html", "Content-Length" => config.message.length.to_s}, [config.message]]
       end
     end
 
-    # HACK: This makes this middleware threadsafe, but is not a very good pattern.
-    # We should rewrite this to use a separate class with instance-level stuff.
-    def call(env)
-      dup._call(env)
-    end
-
     private
 
-    def allowed_routes
-      @allowed_routes ||= begin
-        routes = [config.allowed_routes]
-        routes.flatten!
-        routes.compact!
-        routes.uniq!
-        routes
-      end
-    end
-
-    def allowed?(request)
-      route_matchers.any? { |route_matcher| route_matcher =~ request.path_info }
-    end
-
     def config
-      @config ||= StrongRoutes.config.merge(@options)
-    end
-
-    def enabled?
-      config.enabled?
-    end
-
-    def route_matchers
-      @route_matchers ||= allowed_routes.map { |allowed_route| ::StrongRoutes::RouteMatcher.new(allowed_route) }
+      StrongRoutes.config
     end
   end
 end

--- a/lib/strong_routes/rails/railtie.rb
+++ b/lib/strong_routes/rails/railtie.rb
@@ -24,8 +24,7 @@ module StrongRoutes
         # in after routes are loaded
         app.reload_routes!
 
-        config.strong_routes.allowed_routes ||= []
-        config.strong_routes.allowed_routes += RouteMapper.map(app.routes)
+        config.strong_routes.allowed_routes = RouteMapper.map(app.routes)
       end
     end
   end

--- a/test/strong_routes/allow_test.rb
+++ b/test/strong_routes/allow_test.rb
@@ -7,6 +7,10 @@ describe StrongRoutes::Allow do
   let(:stack) { lambda { |env| [200, {"Content-Type" => "text/plain"}, ["Good"]] } }
 
   context "without allowed routes set" do
+    before do
+      StrongRoutes.config.allowed_routes = []
+    end
+
     it "does not allow access to /users" do
       get "/users"
       _(last_response).wont_be :ok?
@@ -34,14 +38,8 @@ describe StrongRoutes::Allow do
   end
 
   context "with allowed routes set" do
-    let(:users_path) { [/\/users/i] }
-
     before do
-      StrongRoutes.config.allowed_routes = users_path
-    end
-
-    after do
-      StrongRoutes.config.allowed_routes = nil
+      StrongRoutes.config.allowed_routes = ["/users"]
     end
 
     it "allows access to /users" do
@@ -60,31 +58,12 @@ describe StrongRoutes::Allow do
     end
   end
 
-  context "enabled option is false" do
-    let(:app) { StrongRoutes::Allow.new(stack, {enabled: false}) }
-
+  context "when enabled option is false" do
     it "passes request to the next app" do
-      get "/users/profile/anything?stuff=12"
-      _(last_response).must_be :ok?
-    end
-  end
-
-  context "allowed_routes passed to initializer" do
-    let(:app) { StrongRoutes::Allow.new(stack, {allowed_routes: [:users]}) }
-
-    it "allows /users with :users" do
-      get "/users"
-      _(last_response).must_be :ok?
-    end
-
-    it "does not allow /user :user" do
-      get "/user"
-      _(last_response).wont_be :ok?
-    end
-
-    it "allows access to /users/profile/anything?stuff=12 with :users" do
-      get "/users/profile/anything?stuff=12"
-      _(last_response).must_be :ok?
+      StrongRoutes.config.stub :enabled?, false do
+        get "/users/profile/anything?stuff=12"
+        _(last_response).must_be :ok?
+      end
     end
   end
 end

--- a/test/strong_routes/config_test.rb
+++ b/test/strong_routes/config_test.rb
@@ -16,14 +16,29 @@ describe StrongRoutes::Config do
       _(subject.respond_to?(:insert_after)).must_equal true
     end
 
+    it "supports :insert_after?" do
+      _(subject.respond_to?(:insert_after?)).must_equal true
+    end
+
     it "supports :insert_before" do
       _(subject.respond_to?(:insert_before)).must_equal true
+    end
+
+    it "supports :insert_before?" do
+      _(subject.respond_to?(:insert_before?)).must_equal true
     end
   end
 
   describe "#enabled" do
     it "is enabled by default" do
       _(subject).must_be :enabled
+    end
+  end
+
+  describe "#allowed_routes=" do
+    it "maps allowed routes to matchers" do
+      subject.allowed_routes = ["/users"]
+      _(subject.route_matchers).must_equal [StrongRoutes::RouteMatcher.new("/users")]
     end
   end
 end


### PR DESCRIPTION
The initial `Allow` middleware implementation [was not thread-safe](https://github.com/liveh2o/strong_routes/commit/61a3b507e83f6a582d1cee9f36b70306b0fc0eae). A "temporary" (eight years ago!) hack was put in place that simply duped the middleware stack to ensure threadsafety. Not only is this a hack, but it also adds unnecessary overhead to each request since each dup generated more objects that would need to be GC'd.

This change makes the `Allow` middleware thread-safe without duping, and yields a whopping 85x (!) increase in performance (via bin/benchmark):

Before:

    ruby 2.7.6p219 (2022-04-12 revision c9c2245c0a) [arm64-darwin22]
    Warming up --------------------------------------
        Hit    2.318k i/100ms
        Miss   2.317k i/100ms
    Calculating -------------------------------------
        Hit   22.267k (± 2.8%) i/s (44.91 μs/i) - 111.264k in 5.000717s
        Miss  22.266k (± 1.2%) i/s (44.91 μs/i) - 113.533k in 5.099622s

After:

    ruby 2.7.6p219 (2022-04-12 revision c9c2245c0a) [arm64-darwin22]
    Warming up --------------------------------------
        Hit  188.921k i/100ms
        Miss 186.268k i/100ms
    Calculating -------------------------------------
        Hit    1.859M (± 0.5%) i/s (537.92 ns/i) - 9.446M in 5.081332s
        Miss   1.860M (± 1.1%) i/s (537.70 ns/i) - 9.313M in 5.008448s

This implementation uses a simplified Config class that is no longer backed by a hash. This required dropping support for passing config options to the middleware, but that likely was mostly used in tests.