### PR TITLE
Return 404 HEAD response by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,14 @@ StrongRoutes.config.allowed_routes = [ /\A\//i, /\A\/posts/i ]
 Any routes that aren't allowed will return a 404 by default:
 
 ```
-[ 404, { "Content-Type" => "text/html", "Content-Length" => "18" }, [ "Resource Not Found" ] ]
+[ 404, {}, [] ]
 ```
 
-The message that is returned can be specified using the `message` config option:
+The content that is returned can be specified using the `content` config option:
 
 ```Ruby
-StrongRoutes.config.message = File.read(Rails.root.join('public/404.html'))
+StrongRoutes.config.content = File.read(Rails.root.join('public/404.html'))
+StrongRoutes.config.content_type = "text/html"
 ```
 
 ## Contributing

--- a/lib/strong_routes.rb
+++ b/lib/strong_routes.rb
@@ -14,8 +14,8 @@ module StrongRoutes
     @config ||= Config.new
   end
 
-  def self.enabled?
-    config.enabled?
+  def self.response
+    Rack::Response[config.status, config.headers, config.content]
   end
 
   # Initialize the config

--- a/lib/strong_routes/allow.rb
+++ b/lib/strong_routes/allow.rb
@@ -10,7 +10,7 @@ module StrongRoutes
       if StrongRoutes.allowed?(env[Rack::PATH_INFO].to_s)
         @app.call(env)
       else
-        [404, {"Content-Type" => "text/html", "Content-Length" => config.message.length.to_s}, [config.message]]
+        StrongRoutes.response
       end
     end
 

--- a/lib/strong_routes/config.rb
+++ b/lib/strong_routes/config.rb
@@ -1,16 +1,19 @@
+# frozen_string_literal: true
+
 module StrongRoutes
   class Config
     attr_accessor :enabled,
+      :content,
+      :content_type,
       :insert_after,
-      :insert_before,
-      :message
+      :insert_before
 
     attr_reader :allowed_routes, :route_matchers
+    attr_writer :status
 
     def initialize
       @allowed_routes = Set.new
       @enabled = true
-      @message = "Resource Not Found"
       @route_matchers = []
     end
 
@@ -24,12 +27,24 @@ module StrongRoutes
       !!enabled
     end
 
+    def headers
+      if content.present?
+        {Rack::CONTENT_TYPE => content_type || "text/plain"}
+      else
+        {}
+      end
+    end
+
     def insert_after?
       !!insert_after
     end
 
     def insert_before?
       !!insert_before
+    end
+
+    def status
+      @status ||= 404
     end
   end
 end

--- a/test/strong_routes/config_test.rb
+++ b/test/strong_routes/config_test.rb
@@ -8,6 +8,14 @@ describe StrongRoutes::Config do
       _(subject.respond_to?(:allowed_routes)).must_equal true
     end
 
+    it "supports :content" do
+      _(subject.respond_to?(:content)).must_equal true
+    end
+
+    it "supports :content_type" do
+      _(subject.respond_to?(:content_type)).must_equal true
+    end
+
     it "supports :enabled" do
       _(subject.respond_to?(:enabled)).must_equal true
     end
@@ -27,11 +35,9 @@ describe StrongRoutes::Config do
     it "supports :insert_before?" do
       _(subject.respond_to?(:insert_before?)).must_equal true
     end
-  end
 
-  describe "#enabled" do
-    it "is enabled by default" do
-      _(subject).must_be :enabled
+    it "supports :status=" do
+      _(subject.respond_to?(:status=)).must_equal true
     end
   end
 
@@ -39,6 +45,46 @@ describe StrongRoutes::Config do
     it "maps allowed routes to matchers" do
       subject.allowed_routes = ["/users"]
       _(subject.route_matchers).must_equal [StrongRoutes::RouteMatcher.new("/users")]
+    end
+  end
+
+  describe "#enabled?" do
+    it "is true" do
+      _(subject).must_be :enabled
+    end
+  end
+
+  describe "#headers" do
+    it "is an empty hash" do
+      _(subject.headers).must_equal({})
+    end
+
+    context "with content_type: 'text/plain'" do
+      it "is an empty hash" do
+        subject.content_type = "text/plain"
+        _(subject.headers).must_equal({})
+      end
+    end
+
+    context "with content: 'Nope' and content_type: nil" do
+      it "contains Content-Type headers" do
+        subject.content = "Nope"
+        _(subject.headers).must_equal({"content-type" => "text/plain"})
+      end
+    end
+
+    context "with content: 'Nope' and content_type: 'text/plain'" do
+      it "contains Content-Type headers" do
+        subject.content = "Nope"
+        subject.content_type = "text/plain"
+        _(subject.headers).must_equal({"content-type" => "text/plain"})
+      end
+    end
+  end
+
+  describe "#status" do
+    it "is 404" do
+      _(subject.status).must_equal 404
     end
   end
 end


### PR DESCRIPTION
Update the Allow middleware to return a 404 HEAD response (with empty headers and body), and add config options for `:content`, `:content_type`, and `:status`. If `:content` is nil (the default), no headers will be returned. Otherwise, a `content-type` header will be added. If `:content_type` is nil (the default), `text/plain` will be used.

With this change, `:message` is no longer needed and has been removed (use :content instead).