### PR TITLE
Prevent root path from matching all routes

### DIFF
--- a/lib/strong_routes/matcher.rb
+++ b/lib/strong_routes/matcher.rb
@@ -9,7 +9,11 @@ module StrongRoutes
         escaped_route = Regexp.escape(route)
         # Replace dynamic segments in the route with wildcards (e.g. /:foo/users/:id becomes /.*/users/.*)
         escaped_route.gsub!(/:\w+/, ".*")
-        super(/\A#{escaped_route}/i)
+
+        # (:?\?.*)*$ matches the end of the string OR a '?' followed by anything until the end of string
+        # validation of query params is left to the app, but this at least prevents a route such as "/"
+        # from matching "/foo" while still allowing query params
+        super(/\A#{escaped_route}(:?\?.*)*$/i)
       end
     end
   end

--- a/lib/strong_routes/version.rb
+++ b/lib/strong_routes/version.rb
@@ -1,3 +1,3 @@
 module StrongRoutes
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/test/strong_routes/allow_test.rb
+++ b/test/strong_routes/allow_test.rb
@@ -39,7 +39,7 @@ describe StrongRoutes::Allow do
 
   context "with allowed routes set" do
     before do
-      StrongRoutes.config.allowed_routes = ["/users"]
+      StrongRoutes.config.allowed_routes = ["/users", "/users/profile/anything"]
     end
 
     it "allows access to /users" do
@@ -48,7 +48,12 @@ describe StrongRoutes::Allow do
     end
 
     it "allows access to /users?stuff=12" do
-      get "/users/?stuff=12"
+      get "/users?stuff=12"
+      _(last_response).must_be :ok?
+    end
+
+    it "allows access to /users/profile/anything?stuff=12" do
+      get "/users/profile/anything?stuff=12"
       _(last_response).must_be :ok?
     end
 
@@ -56,10 +61,16 @@ describe StrongRoutes::Allow do
       get "/user"
       _(last_response).wont_be :ok?
     end
+  end
 
-    it "allows access to /users/profile/anything?stuff=12" do
-      get "/users/profile/anything?stuff=12"
-      _(last_response).must_be :ok?
+  context "with root route set" do
+    before do
+      StrongRoutes.config.allowed_routes = ["/"]
+    end
+
+    it "does not allow access to /users" do
+      get "/users"
+      _(last_response).wont_be :ok?
     end
   end
 

--- a/test/strong_routes/matcher_test.rb
+++ b/test/strong_routes/matcher_test.rb
@@ -18,7 +18,7 @@ describe StrongRoutes::Matcher do
       subject { StrongRoutes::Matcher.new("/foo") }
 
       it "creates a new matcher" do
-        _(subject).must_equal /\A\/foo(:?\?.*)*$/i
+        _(subject).must_equal(/\A\/foo(:?\?.*)*$/i)
       end
     end
 
@@ -28,7 +28,7 @@ describe StrongRoutes::Matcher do
       subject { StrongRoutes::Matcher.new("/:id/foo/:foo_id/bar") }
 
       it "creates a new matcher" do
-        _(subject).must_equal /\A\/.*\/foo\/.*\/bar(:?\?.*)*$/i
+        _(subject).must_equal(/\A\/.*\/foo\/.*\/bar(:?\?.*)*$/i)
       end
     end
   end

--- a/test/strong_routes/matcher_test.rb
+++ b/test/strong_routes/matcher_test.rb
@@ -18,7 +18,7 @@ describe StrongRoutes::Matcher do
       subject { StrongRoutes::Matcher.new("/foo") }
 
       it "creates a new matcher" do
-        _(subject).must_equal matcher
+        _(subject).must_equal /\A\/foo(:?\?.*)*$/i
       end
     end
 
@@ -28,7 +28,7 @@ describe StrongRoutes::Matcher do
       subject { StrongRoutes::Matcher.new("/:id/foo/:foo_id/bar") }
 
       it "creates a new matcher" do
-        _(subject).must_equal matcher
+        _(subject).must_equal /\A\/.*\/foo\/.*\/bar(:?\?.*)*$/i
       end
     end
   end


### PR DESCRIPTION
Fixes an issue where the "/" path matches all paths.

That issue is described here: https://github.com/liveh2o/strong_routes/issues/12

Included in these changes is a new test case in `allow_spec.rb` that should fail if ran against main:

```
  context "with root route set" do
    before do
      StrongRoutes.config.allowed_routes = ["/"]
    end

    it "does not allow access to /users" do
      get "/users"
      _(last_response).wont_be :ok?
    end
  end
```

I also had to make some assumptions about certain test cases that seemed a little off. I commented on those below to ask for clarification.

This issue, if it is a bug, seems to affect 1.0.2 as well as 2.0.0.

